### PR TITLE
Removing camel-snake-kebab

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,6 @@
                  [io.nervous/eulalie     "0.3.2"]
                  [io.nervous/glossop     "0.1.0"]
 
-                 [camel-snake-kebab      "0.2.5"]
                  [prismatic/plumbing     "0.4.1"]
                  [cheshire               "5.5.0"]]
   :exclusions [[org.clojure/clojure]])

--- a/src/fink_nottle/internal/sns.clj
+++ b/src/fink_nottle/internal/sns.clj
@@ -1,6 +1,5 @@
 (ns fink-nottle.internal.sns
-  (:require [camel-snake-kebab.core :as csk]
-            [cheshire.core :as json]
+  (:require [cheshire.core :as json]
             [clojure.walk :as walk]
             [eulalie.util.xml :as xml]
             [fink-nottle.internal :as i]


### PR DESCRIPTION
... since it does not seem to be used.

To avoid AOT problems on case-insensitive file systems.

See
https://github.com/qerub/camel-snake-kebab/blob/stable/README.md#2015-01-17-030
for more information.
