### PR TITLE
Apply dropping buffer to error-chan when batching

### DIFF
--- a/src/fink_nottle/sqs/channeled.cljc
+++ b/src/fink_nottle/sqs/channeled.cljc
@@ -57,7 +57,7 @@
    & [{:keys [period-ms threshold in-chan error-chan timeout-fn close?]
        :or {period-ms 200 threshold 10 timeout-fn a/timeout close? true}}]]
   (let [in-chan    (or in-chan (a/chan))
-        error-chan (or error-chan (a/chan))]
+        error-chan (or error-chan (a/chan (a/dropping-buffer 10)))]
     (go-catching
       (loop [batch []]
         (let [msg (if (not-empty batch)

--- a/test/fink_nottle/test/sqs/channeled.cljc
+++ b/test/fink_nottle/test/sqs/channeled.cljc
@@ -69,3 +69,12 @@
          (is (= #{"0" "1"}
                 (into #{} (for [f failures]
                             (-> f ex-data :batch-id))))))))))
+
+(deftest batching-channel+failure-without-blocking
+  (let [{:keys [in-chan]}
+        (channeled/batching-channel*
+         failing-batch-mock
+         {:timeout-fn (constantly closed-ch)})]
+    (go-catching
+     (alt! (a/timeout 1000) (is false "Test timed out")
+           (a/onto-chan in-chan (for [id (range 20)] {:id (str id)})) :okay))))


### PR DESCRIPTION
This changes avoids the situation where an error appearing on error-chan will block puts on the in-chan until it is is consumed.

@moea I'm not super happy with the way I've structured the test here, it feels like a bit of a hack to me (although it works correctly) :D

Feel free to suggest changes/improvements/refactorings. Cheers!
